### PR TITLE
Pin build image version to prevent self-lockout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ executors:
     environment:
       IMAGE_NAME: joshhsoj1902/circleci-build-image
     docker:
-      - image: joshhsoj1902/circleci-build-image:latest
+      - image: joshhsoj1902/circleci-build-image:3.0.5
 
 jobs:
   build:


### PR DESCRIPTION
By using "latest" in our CI, it's possible that a bad build will prevent us from deploying a fix.

This will force us to manually update to the new version each time.